### PR TITLE
Add `stickyBodyClass` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ headsUp({
   duration: 0.3,
   easing: 'ease',
   delay: 0,
-  debounce: false
+  debounce: false,
+  stickyBodyClass = 'header-is-stuck'
 })
 ```
 
@@ -56,6 +57,7 @@ Explanation of each option follows:
 * [easing](#easing)
 * [delay](#delay)
 * [debounce](#debounce)
+* [stickyBodyClass](#stickyBodyClass)
 
 ### selector
 
@@ -109,6 +111,19 @@ When the user scrolls, a function is called to check whether it is necessary to 
 
 headsUp({
   debounce: 100
+})
+```
+
+### stickyBodyClass
+
+Applies a class to the `body` element when the sticky header is shown. This can be used to add special styles to other elements on the page.
+
+```es6
+
+// will add the class `is-stuck` to the body when the header is shown
+
+headsUp({
+  stickyBodyClass: 'is-stuck'
 })
 ```
 

--- a/src/headsup.js
+++ b/src/headsup.js
@@ -3,13 +3,16 @@ export default ({
   duration = 0.3,
   easing = 'ease',
   delay = 0,
-  debounce = false
+  debounce = false,
+  stickyBodyClass = 'header-is-stuck'
 } = {}) => {
   let show = true                                         // initial boolean value
   let prev = window.pageYOffset                           // initial window position
 
   const header = document.querySelector(selector)
   const styles = window.getComputedStyle(header)
+
+  const body = document.body;
 
   const headerHeight = () => {                            // computes total height of the element
     const widthAndPadding = header
@@ -26,6 +29,9 @@ export default ({
       .style
       .top = '0'
 
+    body
+      .classList.add(stickyBodyClass)
+
     show = true
   }
 
@@ -33,6 +39,9 @@ export default ({
     header
       .style
       .top = `-${headerHeight()}px`
+
+      body
+        .classList.remove(stickyBodyClass)
 
     show = false
   }
@@ -61,9 +70,11 @@ export default ({
     }
   }
 
-  document                                                // adjust body margin to make space for header
-    .body
-    .style['margin-top'] = `${headerHeight()}px`
+  body
+    .style['margin-top'] = `${headerHeight()}px` // adjust body margin to make space for header
+
+  body
+    .classList.add(stickyBodyClass)
 
   Object.assign(header.style, {                           // assign fixed position and transition to header
     position: 'fixed',

--- a/src/headsup.js
+++ b/src/headsup.js
@@ -12,7 +12,7 @@ export default ({
   const header = document.querySelector(selector)
   const styles = window.getComputedStyle(header)
 
-  const body = document.body;
+  const body = document.body
 
   const headerHeight = () => {                            // computes total height of the element
     const widthAndPadding = header


### PR DESCRIPTION
Thanks for the great library! This works like a charm.

I was using it recently and needed to be able to style other elements on the page based on whether the header was visible or not (I had other sticky elements that needed to move down when the header was shown.)

I modified the code to fit my purpose and thought it might be helpful for others. Let me know if you'd like anything changed.

Thanks again! 😃 